### PR TITLE
Add README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,62 @@
+cabal-doctest
+-------------
+
+[![Build Status](https://travis-ci.org/phadej/cabal-doctest.svg?branch=master)](https://travis-ci.org/phadej/cabal-doctest)
+
+A `Setup.hs` helper for running `doctests`.
+
+Example Usage
+=============
+
+To use this library in your `Setup.hs`, you should specify a `custom-setup`
+section in your `.cabal` file. For example:
+
+```
+custom-setup
+ setup-depends:
+   base >= 4 && <5,
+   Cabal >= 1.10 && <2.1,
+   cabal-doctest >= 1 && <1.1
+```
+
+You'll also need to specify `build-type: Custom` at the top of the `.cabal`
+file. Now put this into your `Setup.hs` file:
+
+```haskell
+module Main where
+
+import Distribution.Extra.Doctest (generateBuildModule)
+import Distribution.Simple (defaultMainWithHooks, UserHooks(..), simpleUserHooks)
+
+main :: IO ()
+main = defaultMainWithHooks simpleUserHooks
+  { buildHook = \pkg lbi hooks flags -> do
+     generateBuildModule "doctests" flags pkg lbi
+     buildHook simpleUserHooks pkg lbi hooks flags
+  }
+```
+
+When you build your project, this `Setup` will generate a `Build_doctests`
+module. To use it in a testsuite, simply do this:
+
+```haskell
+module Main where
+
+import Build_doctests (flags, pkgs, module_sources)
+import Data.Foldable (traverse_)
+import Test.Doctest (doctest)
+
+main :: IO ()
+main = do
+    traverse_ putStrLn args -- optionally print arguments
+    doctest args
+  where
+    args = flags ++ pkgs ++ module_sources
+```
+
+Copyright
+=========
+
+Copyright 2017 Oleg Grenrus.
+
+Available under the BSD 3-clause license.

--- a/cabal-doctest.cabal
+++ b/cabal-doctest.cabal
@@ -18,20 +18,20 @@ copyright:           (c) 2017 Oleg Grenrus
 category:            Distribution
 build-type:          Simple
 cabal-version:       >=1.10
-extra-source-files:  ChangeLog.md
+extra-source-files:  ChangeLog.md README.md
 tested-with:
-  GHC==7.0.4, 
-  GHC==7.2.2, 
-  GHC==7.4.2, 
-  GHC==7.6.3, 
-  GHC==7.8.4, 
-  GHC==7.10.3, 
+  GHC==7.0.4,
+  GHC==7.2.2,
+  GHC==7.4.2,
+  GHC==7.6.3,
+  GHC==7.8.4,
+  GHC==7.10.3,
   GHC==8.0.2
 
 library
   exposed-modules:     Distribution.Extra.Doctest
-  other-modules:       
-  other-extensions:    
+  other-modules:
+  other-extensions:
   build-depends:
     base >=4.3 && <4.11,
     Cabal >= 1.10 && <2.1,


### PR DESCRIPTION
Fixes #1.

Note that the example code given for the `Setup.hs` is subject to changes in the `cabal-doctest` API (see, for instance, https://github.com/ekmett/bytes/pull/33/files#r98675887).