### PR TITLE
Add support for x-doctest-options

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+# 1.0.2 -- 2017-04-xx
+
+* Add support for `x-doctest-options` cabal field
+
 # 1.0.1 -- 2017-02-06
 
 * Add support to `default-extensions` in library.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,8 +1,8 @@
-# 1.0.2 -- 2017-04-xx
+# 1.0.1 -- 2017-05-05
 
-* Add support for `x-doctest-options` cabal field
+* Add support for `x-doctest-options` cabal-file field
 
-# 1.0.1 -- 2017-02-06
+* Proper support for GHC-8.2.1 & Cabal-2.0.0.0
 
 * Add support to `default-extensions` in library.
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ Notes
   See [#5 issue](https://github.com/phadej/cabal-doctest/issues/5) for longer
   explanation.
 
+* You can use `x-doctest-options` field in `test-suite doctests` to
+  pass additional flags to the `doctest`.
+
 Copyright
 =========
 

--- a/cabal-doctest.cabal
+++ b/cabal-doctest.cabal
@@ -1,5 +1,5 @@
 name:                cabal-doctest
-version:             1.0.2
+version:             1.0.1
 synopsis:            A Setup.hs helper for doctests running
 description:
   Currently (beginning of 2017), there isn't @cabal doctest@

--- a/cabal-doctest.cabal
+++ b/cabal-doctest.cabal
@@ -1,5 +1,5 @@
 name:                cabal-doctest
-version:             1.0.1
+version:             1.0.2
 synopsis:            A Setup.hs helper for doctests running
 description:
   Currently (beginning of 2017), there isn't @cabal doctest@


### PR DESCRIPTION
Resolves #9 

I could still implement "magical" addition of `-fobject-code` if there is declared use of `UnboxedTuples` extension; but this approach seems more future proof and less magical.

```

test-suite doctests
  type:           exitcode-stdio-1.0
  main-is:        doctests.hs
  ghc-options:    -Wall -threaded
  hs-source-dirs: tests
  default-language: Haskell2010

  x-doctest-options: -fobject-code

  if !flag(test-doctests)
    buildable: False
  else
    build-depends:
      base,
      directory >= 1.0,
      doctest >= 0.9.1,
      filepath,
      parallel
```