### PR TITLE
Use modern Setup script in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ A `Setup.hs` helper for running `doctests`.
 Example Usage
 =============
 
-See [https://github.com/phadej/cabal-doctest/tree/master/example] for an example package.
+See [https://github.com/phadej/cabal-doctest/tree/master/example] for an
+example package. (Note that the example requires `Cabal-1.24` or later, but
+you can relax this bound safely, although running doctests won't be supported
+on versions of `Cabal` older than 1.24.)
 
 To use this library in your `Setup.hs`, you should specify a `custom-setup`
 section in your `.cabal` file. For example:

--- a/example/Setup.hs
+++ b/example/Setup.hs
@@ -1,6 +1,33 @@
-module Main where
+{-# LANGUAGE CPP #-}
+{-# OPTIONS_GHC -Wall #-}
+module Main (main) where
 
-import Distribution.Extra.Doctest (defaultMainWithDoctests)
+#ifndef MIN_VERSION_cabal_doctest
+#define MIN_VERSION_cabal_doctest(x,y,z) 0
+#endif
 
+#if MIN_VERSION_cabal_doctest(1,0,0)
+
+import Distribution.Extra.Doctest ( defaultMainWithDoctests )
 main :: IO ()
 main = defaultMainWithDoctests "doctests"
+
+#else
+
+#ifdef MIN_VERSION_Cabal
+-- If the macro is defined, we have new cabal-install,
+-- but for some reason we don't have cabal-doctest in package-db
+--
+-- Probably we are running cabal sdist, when otherwise using new-build
+-- workflow
+#warning You are configuring this package without cabal-doctest installed. \
+         The doctests test-suite will not work as a result. \
+         To fix this, install cabal-doctest before configuring.
+#endif
+
+import Distribution.Simple
+
+main :: IO ()
+main = defaultMain
+
+#endif


### PR DESCRIPTION
Now that we've come to a consensus on how `Setup.hs` scripts should look, let's endorse that in the example package.

Fixes #11.