### PR TITLE
Add an explicit Prelude import

### DIFF
--- a/src/Distribution/Extra/Doctest.hs
+++ b/src/Distribution/Extra/Doctest.hs
@@ -227,6 +227,8 @@ generateBuildModule testSuiteName flags pkg lbi = do
       rewriteFile (testAutogenDir </> "Build_doctests.hs") $ unlines
         [ "module Build_doctests where"
         , ""
+        , "import Prelude"
+        , ""
         -- -package-id etc. flags
         , "pkgs :: [String]"
         , "pkgs = " ++ (show $ formatDeps $ testDeps libcfg suitecfg)


### PR DESCRIPTION
To resolve the possible conflicts with projects, which specify NoImplicitPrelude on the build-target level. See #21