### PR TITLE
Add generateBuildModule to haddockHook too

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+# 1.0.6 -- 2018-01-28
+
+* Hook `haddock` build too. Fixes issue when `haddock` fails, as
+  `Build_doctests` isn't generated.
+
 # 1.0.5 -- 2018-01-26
 
 * Add a hack so `Build_doctests` module is automatically added to

--- a/cabal-doctest.cabal
+++ b/cabal-doctest.cabal
@@ -1,5 +1,5 @@
 name:                cabal-doctest
-version:             1.0.5
+version:             1.0.6
 synopsis:            A Setup.hs helper for doctests running
 description:
   Currently (beginning of 2017), there isn't @cabal doctest@

--- a/src/Distribution/Extra/Doctest.hs
+++ b/src/Distribution/Extra/Doctest.hs
@@ -77,7 +77,7 @@ import Distribution.Simple.LocalBuildInfo
        (ComponentLocalBuildInfo (componentPackageDeps), LocalBuildInfo (),
        compiler, withExeLBI, withLibLBI, withPackageDB, withTestLBI)
 import Distribution.Simple.Setup
-       (BuildFlags (buildDistPref, buildVerbosity), fromFlag)
+       (BuildFlags (buildDistPref, buildVerbosity), HaddockFlags (haddockDistPref, haddockVerbosity), fromFlag, emptyBuildFlags)
 import Distribution.Simple.Utils
        (createDirectoryIfMissingVerbose, findFile, rewriteFile)
 import Distribution.Text
@@ -163,6 +163,16 @@ addDoctestsUserHook testsuiteName uh = uh
     -- We cannot use HookedBuildInfo as it let's alter only the library and executables.
     , confHook = \(gpd, hbi) flags ->
         confHook uh (amendGPD testsuiteName gpd, hbi) flags
+    , haddockHook = \pkg lbi hooks flags -> do
+        generateBuildModule testsuiteName (haddockToBuildFlags flags) pkg lbi
+        haddockHook uh pkg lbi hooks flags
+    }
+
+-- | Convert only flags used by 'generateBuildModule'.
+haddockToBuildFlags :: HaddockFlags -> BuildFlags
+haddockToBuildFlags f = emptyBuildFlags
+    { buildVerbosity = haddockVerbosity f
+    , buildDistPref  = haddockDistPref f
     }
 
 data Name = NameLib (Maybe String) | NameExe String deriving (Eq, Show)


### PR DESCRIPTION
As haddock codepath doesn't seem to do the `build`, we need
to generate `Build_doctests` module in `haddockHook` too.

Otherwise `cabal new-haddock` fails, as `Build_doctests` in
`other-modules`, but doesn't exist in the file-system.