### PR TITLE
Add explicit exports to the generated Build_doctest module.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+# next
+
+* Add an explicit exports list to the generated `Build_doctest` module.
+  This eliminates a warning from `-Wmissing-export-list` on GHC 8.4.
+
 # 1.0.6 -- 2018-01-28
 
 * Hook `haddock` build too. Fixes issue when `haddock` fails, as

--- a/src/Distribution/Extra/Doctest.hs
+++ b/src/Distribution/Extra/Doctest.hs
@@ -234,7 +234,7 @@ generateBuildModule testSuiteName flags pkg lbi = do
     -- First, we create the autogen'd module Build_doctests.
     -- Initially populate Build_doctests with a simple preamble.
     writeFile buildDoctestsFile $ unlines
-      [ "module Build_doctests where"
+      [ "module Build_doctests (Name, Component, pkgs, flags, module_sources, components) where"
       , ""
       , "import Prelude"
       , ""


### PR DESCRIPTION
This eliminates a warning from `-Wmissing-export-list` on GHC 8.4.