### PR TITLE
Don't import Prelude in the generated Build_doctests modules.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,11 @@
+# next
+
+* Don't import `Prelude` in the generated `Build_doctests` modules.
+
+  `Prelude` is a magical module name, and it may be useful for users
+  to define their own `Prelude` modules which may not coincide with
+  the `Prelude` from `base`.
+
 # 1.0.6 -- 2018-01-28
 
 * Hook `haddock` build too. Fixes issue when `haddock` fails, as

--- a/src/Distribution/Extra/Doctest.hs
+++ b/src/Distribution/Extra/Doctest.hs
@@ -234,9 +234,13 @@ generateBuildModule testSuiteName flags pkg lbi = do
     -- First, we create the autogen'd module Build_doctests.
     -- Initially populate Build_doctests with a simple preamble.
     writeFile buildDoctestsFile $ unlines
-      [ "module Build_doctests where"
+      [ "{-# LANGUAGE NoImplicitPrelude #-}"
+      , "module Build_doctests where"
       , ""
-      , "import Prelude"
+      , "import Data.Eq (Eq)"
+      , "import Data.Maybe (Maybe (Nothing))"
+      , "import Data.String (String)"
+      , "import Text.Show (Show)"
       , ""
       , "data Name = NameLib (Maybe String) | NameExe String deriving (Eq, Show)"
       , "data Component = Component Name [String] [String] [String] deriving (Eq, Show)"


### PR DESCRIPTION
Prelude is a magical module name, and it may be useful for users
to define their own Prelude modules which may not coincide with
the Prelude from base.