### PR TITLE
Cabal 2.5 compatibility

### DIFF
--- a/cabal-doctest.cabal
+++ b/cabal-doctest.cabal
@@ -42,7 +42,7 @@ library
   other-extensions:
   build-depends:
     base >=4.3 && <4.13,
-    Cabal >= 1.10 && <2.5,
+    Cabal >= 1.10 && <2.6,
     filepath,
     directory
   hs-source-dirs:      src

--- a/src/Distribution/Extra/Doctest.hs
+++ b/src/Distribution/Extra/Doctest.hs
@@ -91,6 +91,11 @@ import Data.IORef (newIORef, modifyIORef, readIORef)
 import Distribution.Simple.BuildPaths
        (autogenComponentModulesDir)
 #endif
+
+#if MIN_VERSION_Cabal(2,5,0)
+import Distribution.Types.LibraryName (libraryNameString)
+#endif
+
 #if MIN_VERSION_Cabal(2,0,0)
 import Distribution.Types.MungedPackageId
        (MungedPackageId)
@@ -432,7 +437,9 @@ generateBuildModule testSuiteName flags pkg lbi = do
        isSpecific _                     = False
 
     mbLibraryName :: Library -> Name
-#if MIN_VERSION_Cabal(2,0,0)
+#if MIN_VERSION_Cabal(2,5,0)
+    mbLibraryName = NameLib . fmap unUnqualComponentName . libraryNameString . libName
+#elif MIN_VERSION_Cabal(2,0,0)
     -- Cabal-2.0 introduced internal libraries, which are named.
     mbLibraryName = NameLib . fmap unUnqualComponentName . libName
 #else


### PR DESCRIPTION
This allows us to build this packaged and things that depend on it using fairly recent GHC HEAD.