### PR TITLE
Make Distribution.Extra.Doctest -Wall-clean

### DIFF
--- a/cabal-doctest.cabal
+++ b/cabal-doctest.cabal
@@ -47,3 +47,7 @@ library
     directory
   hs-source-dirs:      src
   default-language:    Haskell2010
+  ghc-options:         -Wall
+  if !impl(ghc >= 7.2)
+    -- Work around a pattern-match coverage checking bug in GHC 7.0
+    ghc-options:       -fno-warn-overlapping-patterns


### PR DESCRIPTION
An unused `autogenModulesDir` import causes `doctest` to fail to build with `Cabal-3.0.0.0`, so I decided that it was time to just bite the bullet and make the code in `doctest` compile without `-Wall` warnings. Thankfully, accomplishing this feat proved not to be that difficult. There's one mysterious pattern-match coverage check warning related to `parseComponentName` that _only_ occurs on GHC 7.0, but I strongly suspect that to be due to an old GHC bug, so I decided to simply turn on `-fno-warn-overlapping-patterns` when building with 7.0.