### PR TITLE
Tell GHC to ignore package environments (where possible).

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,22 @@ module Main where
 
 import Build_doctests (flags, pkgs, module_sources)
 import Data.Foldable (traverse_)
+import System.Environment.Compat (unsetEnv)
 import Test.DocTest (doctest)
 
 main :: IO ()
 main = do
     traverse_ putStrLn args -- optionally print arguments
+    unsetEnv "GHC_ENVIRONMENT" -- see 'Notes'; you may not need this
     doctest args
   where
     args = flags ++ pkgs ++ module_sources
 ```
+
+(The `System.Environment.Compat` module is from the `base-compat`
+package. That's already in the transitive closure of `doctest`'s
+dependencies. If you don't need to support GHC 7.6 or earlier, you can
+use `System.Environment` from `base` instead.)
 
 Example with multiple .cabal components
 ---------------------------------------
@@ -86,6 +93,7 @@ module Main where
 
 import Build_doctests (Component (..), components)
 import Data.Foldable (for_)
+import System.Environment.Compat (unsetEnv)
 import Test.DocTest (doctest)
 
 main :: IO ()
@@ -94,6 +102,7 @@ main = for_ components $ \(Component name flags pkgs sources) -> do
     putStrLn "----------------------------------------"
     let args = flags ++ pkgs ++ sources
     for_ args putStrLn
+    unsetEnv "GHC_ENVIRONMENT"
     doctest args
 ```
 
@@ -114,10 +123,12 @@ import Build_doctests
        (flags,            pkgs,            module_sources,
         flags_exe_my_exe, pkgs_exe_my_exe, module_sources_exe_my_exe)
 import Data.Foldable (traverse_)
+import System.Environment.Compat (unsetEnv)
 import Test.DocTest
 
 main :: IO ()
 main = do
+    unsetEnv "GHC_ENVRIONMENT"
     -- doctests for library
     traverse_ putStrLn libArgs
     doctest libArgs

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ main = do
 
 (The `System.Environment.Compat` module is from the `base-compat`
 package. That's already in the transitive closure of `doctest`'s
-dependencies. If you don't need to support GHC 7.6 or earlier, you can
+dependencies. `System.Environment.unsetEnv` was added with GHC 7.8 so,
+if you don't need to support versions of GHC older than 7.8, you can
 use `System.Environment` from `base` instead.)
 
 Example with multiple .cabal components

--- a/README.md
+++ b/README.md
@@ -221,6 +221,20 @@ or
         :: Language.Haskell.TH.Syntax.Name -> Language.Haskell.TH.Lib.ExpQ
 ```
 
+* From version 2, Stack sets the `GHC_ENVRIONMENT` variable, and GHC
+  (as invoked by `doctest`) will pick that up. This is undesirable:
+  `cabal-doctest` passes all the necessary information on the command
+  line already, and can lead to ambiguous module errors as GHC will
+  load the environment in addition to what `cabal-doctest` instructs
+  it to.
+
+  Hence, `cabal-doctest` tells GHC to ignore package environments
+  altogether on the command line. However, this is only possible since
+  GHC 8.2. If you are using `cabal-doctest` with Stack 2 and GHC 8.0
+  or earlier and seeing ambiguous module errors or other mysterious
+  failures, try manually unsetting `GHC_ENVIRONMENT` before invoking
+  `doctest`.
+
 Copyright
 ---------
 

--- a/multiple-components-example/multiple-components-example.cabal
+++ b/multiple-components-example/multiple-components-example.cabal
@@ -50,9 +50,10 @@ test-suite doctests
   main-is:              doctests.hs
   build-depends:
       base
-    , doctest                      >=0.15 && <0.17
+    , base-compat                  >=0.11.0 && <0.12
+    , doctest                      >=0.15   && <0.17
     , multiple-components-example
-    , QuickCheck                   >=2.12 && <2.14
+    , QuickCheck                   >=2.12   && <2.14
     , template-haskell
 
   ghc-options:          -Wall -threaded

--- a/multiple-components-example/multiple-components-example.cabal
+++ b/multiple-components-example/multiple-components-example.cabal
@@ -50,7 +50,7 @@ test-suite doctests
   main-is:              doctests.hs
   build-depends:
       base
-    , base-compat                  >=0.11.0 && <0.12
+    , base-compat                  >=0.10.5 && <0.12
     , doctest                      >=0.15   && <0.17
     , multiple-components-example
     , QuickCheck                   >=2.12   && <2.14

--- a/multiple-components-example/tests/doctests.hs
+++ b/multiple-components-example/tests/doctests.hs
@@ -2,6 +2,7 @@ module Main where
 
 import Build_doctests (Component (..), components)
 import Data.Foldable (for_)
+import System.Environment.Compat (unsetEnv)
 import Test.DocTest (doctest)
 
 main :: IO ()
@@ -10,4 +11,5 @@ main = for_ components $ \(Component name flags pkgs sources) -> do
     putStrLn "----------------------------------------"
     let args = flags ++ pkgs ++ sources
     for_ args putStrLn
+    unsetEnv "GHC_ENVIRONMENT"
     doctest args

--- a/simple-example/simple-example.cabal
+++ b/simple-example/simple-example.cabal
@@ -37,8 +37,9 @@ test-suite doctests
   main-is:          doctests.hs
   build-depends:
       base
-    , doctest           >=0.15 && <0.17
-    , QuickCheck        >=2.12 && <2.14
+    , base-compat       >=0.11.0 && <0.12
+    , doctest           >=0.15   && <0.17
+    , QuickCheck        >=2.12   && <2.14
     , simple-example
     , template-haskell
 

--- a/simple-example/simple-example.cabal
+++ b/simple-example/simple-example.cabal
@@ -37,7 +37,7 @@ test-suite doctests
   main-is:          doctests.hs
   build-depends:
       base
-    , base-compat       >=0.11.0 && <0.12
+    , base-compat       >=0.10.5 && <0.12
     , doctest           >=0.15   && <0.17
     , QuickCheck        >=2.12   && <2.14
     , simple-example

--- a/simple-example/tests/doctests.hs
+++ b/simple-example/tests/doctests.hs
@@ -2,11 +2,13 @@ module Main where
 
 import Build_doctests (flags, pkgs, module_sources)
 import Data.Foldable (traverse_)
+import System.Environment.Compat (unsetEnv)
 import Test.DocTest (doctest)
 
 main :: IO ()
 main = do
     traverse_ putStrLn args
+    unsetEnv "GHC_ENVIRONMENT"
     doctest args
   where
     args = flags ++ pkgs ++ module_sources


### PR DESCRIPTION
All the necessary package ids are passed on the command line already;
any package environments picked up elsewhere (e.g., via
`GHC_ENVIRONMENT`, which is now being set by Stack) are, at best,
superfluous and at worst causing problems.

This is necessarily best-effort, as telling GHC to ignore a package
environment with only command-line flags was added after the package
environment feature itself. I've added a note to the README for any
users left in an unfortunate situation by this.